### PR TITLE
Include 'null' data when excluding charms

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -107,7 +107,12 @@ module.exports = function (setup) {
         }
 
         if (exclude.length) {
-          whereClause += ' AND NOT ( ' + exclude.map(function (id) { return term }).join(' OR ') + ' ) '
+          // Implicitly include 'null' charm ID when excluding special charms
+          if (type === 'charm') {
+            whereClause += ' AND ( ' + exclude.map(function (id) { return 'charm_id != ?' }).join(' AND ') + ' OR charm_id IS NULL )'
+          } else {
+            whereClause += ' AND NOT ( ' + exclude.map(function (id) { return term }).join(' OR ') + ' ) '
+          }
           values = values.concat(exclude)
         }
       }


### PR DESCRIPTION
Hi Geno,

I've been using your client lately to update populations and noticed that rows where `charm_id` is null weren't being captured from the DB. This fix improves sample sizes rather significantly in certain locations.